### PR TITLE
Minikube DNS malfunction for deployed pod

### DIFF
--- a/labs/13-ConfigMap/nginx-deployment.yaml
+++ b/labs/13-ConfigMap/nginx-deployment.yaml
@@ -34,3 +34,8 @@ spec:
               path: virtualhost/virtualhost.conf # dig directory
       - name: log
         emptyDir: {}
+      # If the minikube DNS isn't working, uncomment the lines below.
+      #hostAliases:
+      #  - ip: 62.149.144.114
+      #    hostnames:
+      #      - "www.sunnyvale.it"


### PR DESCRIPTION
The pod crash and show this error:
- nginx: [emerg] host not found in upstream "www.sunnyvale.it" in /etc/nginx/virtualhost/virtualhost.conf:2